### PR TITLE
[ci skip] adding user @jgriesfeller

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @jgliss
 * @avaldebe
+* @jgriesfeller

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,5 +56,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - jgriesfeller
     - avaldebe
     - jgliss


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @jgriesfeller as instructed in #13.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #13